### PR TITLE
refactor(row-events): fixed attendance terminology and applied minor styling for mobile view

### DIFF
--- a/components/row-events.js
+++ b/components/row-events.js
@@ -21,7 +21,7 @@ const RowEvent = props => {
         <span className="card_icons">
           <Icon name="users" />
           {props.yesCount}
-          {moment(props.time).isAfter() ? ' attending' : ' attended'}
+          {props.status === 'upcoming' ? ' attending' : ' attended'}
         </span>
         <span className="card_icons">
           <Icon name="log out" />

--- a/components/row-events.js
+++ b/components/row-events.js
@@ -20,10 +20,13 @@ const RowEvent = props => {
         </span>
         <span className="card_icons">
           <Icon name="users" />
-          {`${props.yesCount} attended`}
+          {props.yesCount}
+          {moment(props.time).isAfter() ? ' attending' : ' attended'}
         </span>
-        <Icon name="log out" />
-        {props.venue === undefined ? 'Free session' : 'Free entry'}
+        <span className="card_icons">
+          <Icon name="log out" />
+          {props.venue === undefined ? 'Free session' : 'Free entry'}
+        </span>
       </Card.Content>
       <style jsx>{`
         .card_venue {
@@ -31,6 +34,12 @@ const RowEvent = props => {
         }
         .card_icons {
           margin-right: 15px;
+        }
+        @media (max-width: 700px) {
+          .card_icons {
+            display: flex;
+            margin: 5px 0;
+          }
         }
       `}</style>
     </Card>

--- a/pages/events.js
+++ b/pages/events.js
@@ -53,6 +53,7 @@ export default publicPage(
                         time={event.time}
                         venue={event.venue}
                         link={event.link}
+                        status={event.status}
                       />
                     </Card.Group>
                   ))}
@@ -68,6 +69,7 @@ export default publicPage(
                         time={event.time}
                         venue={event.venue}
                         link={event.link}
+                        status={event.status}
                       />
                     </Card.Group>
                   ))}


### PR DESCRIPTION
Resolves issue #15 

---

**Mobile view before:**

![coderplex org-events iphone 6](https://user-images.githubusercontent.com/5133505/31700023-6b2190c0-b37b-11e7-9f8f-5f8f59d04fb3.png)

---

**Mobile view after:**

![localhost-3000-events iphone 6](https://user-images.githubusercontent.com/5133505/31700027-73c60d1e-b37b-11e7-8f21-c2ce2fd40003.png)

---

**Attending vs Attended:**

![localhost-3000-events iphone 6 1](https://user-images.githubusercontent.com/5133505/31700100-e983ac78-b37b-11e7-854f-2f539d59e1e6.png)

