### PR TITLE
use smaller brand image

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -136,8 +136,8 @@ export default props => {
           align-items: center;
         }
         .nav__logo img {
-          width: 72px;
-          height: 72px;
+          width: 50px;
+          height: 50px;
           margin-right: 5px;
         }
         .nav__links {


### PR DESCRIPTION
Resized the brand logo to be 50px / 50px, that way it fits the header better.