### PR TITLE
Z-index glitch

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -87,6 +87,7 @@ export default props => {
           padding: 5px 20px;
           width: 100%;
           background: #fff;
+          z-index: 1000
         }
         .header__container {
           max-width: 1280px;


### PR DESCRIPTION
On several pages, components that appear/animate to "rise" seem to overlap the header component. 
I've added a z-index definition to push the header component to the highest layer so that no other component overlaps / shadows it.
![image](https://user-images.githubusercontent.com/5159834/31824701-8a25200a-b5cd-11e7-9821-08d2bf359298.png)
![image](https://user-images.githubusercontent.com/5159834/31824730-96f80324-b5cd-11e7-8989-faa3e3d6a4ed.png)
![image](https://user-images.githubusercontent.com/5159834/31824763-acd7ce40-b5cd-11e7-83d4-3ee39ef1b8a2.png)
